### PR TITLE
Add documentUrlPatterns so it only appears on MDN pages

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,7 +2,8 @@ browser.contextMenus.create({
   id: "mdn-edit-page",
   title: "Edit page",
   contexts: ["all"],
-  checked: false
+  checked: false,
+  documentUrlPatterns: ["*://developer.mozilla.org/*", "*://developer.allizom.org/*"]
 });
 
 browser.contextMenus.onClicked.addListener((info, tab) => {


### PR DESCRIPTION
I propose to add documentUrlPatterns so the contextMenu only appears on developer.mozilla.org and also on staging developer.allizom.org.